### PR TITLE
docs: protect synced FAQ path in AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,9 @@ Invoke as `/contextdocs:command-name` in Claude Code, or as prompts in Codex CLI
 - `content-filter-guard.sh` — Write guard for high-risk OSS files
 - `context-guard-stop.sh` — session-end context doc nudge (Tier 1)
 - `context-commit-guard.sh` — pre-commit context doc enforcement (Tier 2)
+
+## Synced Documentation Paths
+
+These paths are consumed by external sync pipelines. Treat as protected — the upstream build fails if they go missing.
+
+- `docs/faq/index.md` — FAQ scaffold for the help-centre FAQPage schema (issue #25). Synced to `littlebearapps.com/help/contextdocs/faq/` by the marketing-site `scripts/docs-sync.config.ts` mapping under `contextdocs`. **Do not delete or move.** **Update only when** an answer goes stale (new install path, retired feature, top support driver becomes a new question) — not on every release. Keep the question set lean: each H2 must end with `?`, every answer must be complete (no placeholders), and Australian English / banned-phrase rules from `.claude/rules/doc-standards.md` apply.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Pure Markdown Claude Code plugin — no JavaScript, no Python, no build step, no
 | `.claude/agents/docs-freshness.md` | Read-only agent — checks documentation freshness, suggests PitchDocs commands *(PitchDocs)* |
 | `.claude/rules/doc-standards.md` | Auto-loaded quality rule — 4-Question Test, Lobby Principle, banned phrases *(PitchDocs)* |
 | `.claude/rules/docs-awareness.md` | Auto-loaded trigger map — suggests PitchDocs commands when docs-relevant work is detected *(PitchDocs)* |
+| `docs/faq/index.md` | Synced FAQ — emits Schema.org `FAQPage` JSON-LD on `littlebearapps.com/help/contextdocs/faq/` via the marketing-site sync (issue #25). **Do not delete or move** — upstream build hard-fails. **Update only when** an answer goes stale, not on every release |
 
 ## Known Limitations
 


### PR DESCRIPTION
## Summary

Follow-up to #25 / #26. Adds explicit "do not delete" + "update only when needed" guardrails for `docs/faq/index.md` so future Claude Code (and other AI tool) sessions don't sweep it away during cleanup or rewrite it on every release.

- **AGENTS.md** (canonical): new "Synced Documentation Paths" section explaining what `docs/faq/index.md` is, that the marketing-site sync hard-fails without it, and the precise update trigger (an answer goes stale — not every release).
- **CLAUDE.md** (Claude Code bridge): one row added to the Key Files table mirroring the same guardrail, so it's immediately visible to Claude Code at session start.

Other bridges (`.cursorrules`, Copilot instructions, `.windsurfrules`, `.clinerules`, `GEMINI.md`) are not edited because this repo's primary AI consumer is Claude Code itself, and AGENTS.md is the canonical source if those bridges ever get added.

## Why this is "where needed"

- `MEMORY.md` is for cross-session learned patterns, not project policy → not the right home.
- `.claude/rules/*` rules cover *context-file* hygiene (line budgets, Signal Gate, AGENTS↔bridge consistency). The FAQ is user-facing docs, not a context file → out of scope.
- Hooks like `content-filter-guard.sh` only protect against API content-filter blocks on Write — there's no existing pattern for "do not delete this path" that would benefit from extension here.

So: AGENTS.md + CLAUDE.md only. Surgical.

## Verification

- AGENTS.md: 59 lines (budget <120) ✅
- CLAUDE.md: 56 lines (budget <80) ✅
- `typos` clean ✅
- Banned-phrase scan clean ✅
- `bash tests/check-version-consistency.sh` green ✅
- `python3 tests/validate-frontmatter.py` green ✅

## Test plan

- [ ] Visual: confirm "Synced Documentation Paths" renders correctly in AGENTS.md preview.
- [ ] Visual: confirm new row appears at the bottom of the CLAUDE.md Key Files table.
- [ ] CI: lint / links / consistency / validate-plugin / CodeQL / Socket / CodeRabbit all green.
- [ ] (Already proven) `docs/faq/index.md` itself is unchanged and remains live on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)